### PR TITLE
ff4j-demo: fixing configuration of the jetty-maven-plugin issue.

### DIFF
--- a/ff4j-demo/pom.xml
+++ b/ff4j-demo/pom.xml
@@ -192,7 +192,9 @@
 			  <artifactId>jetty-maven-plugin</artifactId>
 			  <version>9.3.2.v20150730</version>
 			  <configuration>
-			 	<contextPath>/ff4j-demo</contextPath>
+				  <webApp>
+					  <contextPath>/ff4j-demo</contextPath>
+				  </webApp>
 			    <stopPort>9965</stopPort>
 			    <stopKey>foo</stopKey>
 			    <stopWait>10</stopWait>


### PR DESCRIPTION
In jetty maven plugin version 8 and 9, contextPath is a sub tag of webApp and not directly a sub tag of configuration.

With the current config, after an:

`mvn jetty:run`

An attempt to access http://localhost:8080/ff4j-demo will generate a 404 http error

With the change everything works fine and one can flipp at will these nice planets

More about this here: [Root context path with maven jetty plugin](https://stackoverflow.com/questions/8685970/setting-root-context-path-with-maven-jetty-plugin)